### PR TITLE
updated contactSchema to split the 'name' field into 'firstName' and …

### DIFF
--- a/server/models/Job.js
+++ b/server/models/Job.js
@@ -8,9 +8,14 @@ const contactSchema = new Schema({
     //     type: Schema.Types.ObjectId,
     //     default: () => new Types.ObjectId()
     // },
-    name: {
+    firstName: {
         type: String,
-        require: "Please enter your contact's name",
+        require: "Please enter your contact's first name",
+        trim: true
+    },
+    lastName: {
+        type: String,
+        require: "Please enter your contact's  last name",
         trim: true
     },
     email: {
@@ -37,10 +42,12 @@ const jobSchema = new Schema({
         required: 'Please enter the job employer name',
         trim: true
     },
-    applicationDate: {
+    lastUpdated: {
         type: Date,
-        default: Date.now,
-        // get: appDate => dateFormat(appDate)
+        required: 'Please enter a the updated Date',
+        trim: true,
+        default: Date.now
+        //get: appDate => dateFormat(appDate)
     },
     applicationStatus: {
         type: String,

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -11,7 +11,8 @@ const typeDefs = gql`
 
     type Contact {
         _id: ID
-        name: String,
+        firstName: String,
+        lastName: String,
         email: String,
         phone: String
     }
@@ -20,7 +21,7 @@ const typeDefs = gql`
         _id: ID
         jobTitle: String
         employer: String
-        applicationDate: Date
+        lastUpdated: Date
         applicationStatus: String
         username: String
         contacts: [Contact]
@@ -30,14 +31,16 @@ const typeDefs = gql`
         users: [User]
         test: String
         jobs(username: String): [Job]
+        singleJob(_id: ID!): Job
     }
 
     type Mutation {
-        addJob(username: String!, jobTitle: String!, employer: String!, applicationStatus: String!): Job
+        addJob(username: String!, jobTitle: String!, employer: String!, applicationStatus: String!, lastUpdated: String!): Job
         deleteJob(_id: ID!): Job
-        updateJob(_id: ID, jobTitle: String, employer: String, applicationStatus: String): Job
-        addContact(_id: ID!, name: String!, email: String!, phone: String!): Job
-        updateContact(name: String!, email: String!, phone: String!): Contact
+        updateJob(_id: ID!, jobTitle: String, employer: String, applicationStatus: String, lastUpdated: String): Job
+        addContact(_id: ID!, firstName: String!, lastName: String! email: String!, phone: String!): Job
+        deleteContact(_id: ID!): Job
+        updateContact(_id: ID!, firstName: String, lastName: String, email: String, phone: String): Contact
     }
 `
 


### PR DESCRIPTION
- updated contactSchema to split the 'name' field into 'firstName' and 'lastName'
- added a deleteContact resolver, fixed the updateContact resolver to search by _id rather than by contact name
- updated the jobSchema to have the date field be 'lastupdated' rather than 'applicationDate'
- added a query to the resolvers for getting a single Job by _id
- all dates are converted to the graphql Date scalar using the npm package graphql-iso-date

-tested endpoint in Apollo sandbox to make sure added queries and mutations work, and existing one's that were updated did not lose function.